### PR TITLE
#164691212 Integrate coveralls for test coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 
 install:
 - pip install -r requirements.txt
+- pip install coveralls
 
 after_success:
 - coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Authors Haven - A Social platform for the creative at heart.
 [![Build Status](https://travis-ci.com/aqua-organisation/ah-django-Aqua.svg?branch=develop)](https://travis-ci.com/aqua-organisation/ah-django-Aqua)
+[![Coverage Status](https://coveralls.io/repos/github/aqua-organisation/ah-django-Aqua/badge.svg?branch=develop)](https://coveralls.io/github/aqua-organisation/ah-django-Aqua?branch=develop)
 =======
 
 ## Vision

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+certifi==2019.3.9
+chardet==3.0.4
 coverage==4.5.3
 dj-database-url==0.5.0
 Django==2.1.7
@@ -6,10 +8,14 @@ django-extensions==2.1.6
 django-heroku==0.3.1
 django-nose==1.4.6
 djangorestframework==3.9.2
+docopt==0.6.2
 gunicorn==19.9.0
+idna==2.8
 nose==1.3.7
 psycopg2==2.7.7
 PyJWT==1.7.1
 pytz==2018.9
+requests==2.21.0
 six==1.12.0
+urllib3==1.24.1
 whitenoise==4.1.2


### PR DESCRIPTION
#### What does this PR do?

Integrate coveralls to enable reporting on test coverage.

#### Description of Task to be completed?

-    Add coveralls token to the .travis.yml file
-    Add coveralls badge to README.md file
-    Add command for installation of coveralls by TravisCI in the travis.yml file
    by TravisCI

#### How should this be manually tested?

-   Click on the coverage badge in the screenshots section below.
-    This will take you to the coveralls site where you can view additional
    information about the coverage report.

#### Any background context you want to provide?

- The application is configured to use the Django-nose test suite to run the tests and coverage checks  are run when `python manage.py test` is run in the `script` section of the `.travis.yml` file. The coverage report is then sent to coveralls by a call to coveralls in `after-success` section of the `.travis.yml` file
 -  The coverage badge in the README file points to the develop branch and is expected to have a status [![Coverage Status](https://coveralls.io/repos/github/aqua-organisation/ah-django-Aqua/badge.svg?branch=develop)](https://coveralls.io/github/aqua-organisation/ah-django-Aqua?branch=develop) until this PR is merged into develop

What are the relevant pivotal tracker stories?

#164691212

###Screenshots

-    Below is the badge for the coverage on this branch
    [![Coverage Status](https://coveralls.io/repos/github/aqua-organisation/ah-django-Aqua/badge.svg?branch=ch-integrate-coveralls-164691212)](https://coveralls.io/github/aqua-organisation/ah-django-Aqua?branch=ch-integrate-coveralls-164691212)
