### PR TITLE
#164691215 Validate User Signup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,10 +80,12 @@ celerybeat-schedule
 .env
 
 # virtualenv
+
 venv/
 ENV/
 myenv/
 .local/
+newenv/
 
 # pipenv
 Pipfile
@@ -100,3 +102,19 @@ db.sqlite3
 
 # VSCODE
 .vscode/
+
+#pytest
+.pytest_cache/
+__pycache__/
+
+
+#ENV VARIABLES
+.gitignore
+newenv/"sendgrid.env" 
+sendgrid.env
+newenv/".env"
+.env
+env.example
+newenv/*
+environment/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 
 install:
 - pip install -r requirements.txt
-- pip install coveralls
+- pip install coveralls 
 
 after_success:
 - coveralls
@@ -21,3 +21,4 @@ script:
   
 after_success:
 - coveralls
+

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -4,16 +4,20 @@ from rest_framework import serializers
 
 from .models import User
 
+import re
+
 
 class RegistrationSerializer(serializers.ModelSerializer):
     """Serializers registration requests and creates a new user."""
 
+    
     # Ensure passwords are at least 8 characters long, no longer than 128
     # characters, and can not be read by the client.
     password = serializers.CharField(
         max_length=128,
         min_length=8,
         write_only=True
+
     )
 
     # The client should not be able to send a token along with a registration
@@ -28,6 +32,30 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
+        password = validated_data.get('password') #we get a key from the dictionary validated data
+        email = validated_data.get('email')
+        username = validated_data.get('username')
+        pattern = re.compile(
+                r"^(?=.*[A-Za-z])(?=.*\d)[A-Za-z\d]{8,128}$"
+            )
+        if not pattern.match(password):
+            raise serializers.ValidationError(
+                {
+                    "password" :[
+                    "password must contain a numeric character"
+                    ]
+                }
+                )
+
+        
+        elif len(username)< 4 or not username.isalnum():
+            raise serializers.ValidationError(
+                {
+                    "username" :[
+                    "username should be atleast 4 characters long and shouldnt contain special characters"
+                    ]
+                }
+                )
         return User.objects.create_user(**validated_data)
 
 

--- a/authors/apps/authentication/tests/test_data.py
+++ b/authors/apps/authentication/tests/test_data.py
@@ -1,7 +1,7 @@
 valid_user = {
     "username" : "henryjones",
     "email" : "hjones@email.com",
-    "password" : "T35ting-i2E"
+    "password" : "T35tingi2E"
 }
 valid_user2 ={
     "username" : "peter",
@@ -11,12 +11,12 @@ valid_user2 ={
 user_with_existing_email = {
     "username": "peter",
     "email" : "hjones@email.com",
-    "password" : "T35ting-i2E"
+    "password" : "T35tingi2E"
 }
 user_with_existing_username = {
     "username" : "henryjones",
     "email": "peter@email.com",
-    "password": "T35ting-i2E"
+    "password": "T35tingi2E"
 }
 user_without_password = {
     "username": "henryjones",
@@ -24,16 +24,37 @@ user_without_password = {
 }
 user_without_username = {
     "email": "hjones@email.com",
-    "password": "T35ting-i2E"
+    "password": "T35tingi2E"
 }
 user_without_email = {
     "username" : "henryjones",
-    "password": "T35ting-i2E"
+    "password": "T35tingi2E"
 }
 user_with_little_password = {
     "username": "peter2",
     "email": "peter@gmail.com",
     "password": "Enter"
 }
+user_with_short_username = {
+                "username": "pet",
+                "email": "peter@email.com",
+                "password": "Password8"
+        }
+user_with_a_non_numeric_password = {
+                "username": "peter",
+                "email": "peter@email.com",
+                "password": "Password"
+        }
+username_with_special_characters = {
+                "username": "peter.",
+                "email": "peter@email.com",
+                "password": "Password9"
+        }
+message = "username should be atleast 4 characters long and shouldnt contain special characters"
+invalid_email = {
+                "username": "peter",
+                "email": "peter@.com",
+                "password": "Password1"
+        }
 invalid_token = "icVpZnJlZCIsImV4cCI6MTU1ODY3"
 expired_token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6InJlaWZyZWQzM0BnbWFpbC5jb20iLCJleHAiOjE1NTQxOTYxMTd9.TAJa94Vvj7S_4nCDJqWGItbRBEsvpybM3Qc_Pp-NYwE"

--- a/authors/apps/authentication/tests/test_register.py
+++ b/authors/apps/authentication/tests/test_register.py
@@ -6,7 +6,12 @@ from .app_urls import register_url
 from .test_data import (
     valid_user, valid_user2,
     user_with_existing_email, user_with_existing_username,
-    user_with_little_password
+    user_with_little_password,
+    user_with_a_non_numeric_password,
+    username_with_special_characters,
+    invalid_email,
+    user_with_short_username,
+    message
     )
 
 from ..models import User
@@ -23,7 +28,6 @@ class RegistrationAPIViewTestCase(TestCase):
     def test_api_can_create_a_user(self):
         response = self.client.post(
             register_url, {"user": valid_user2}, format="json")
-            
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_api_cannot_create_a_user_with_existing_email(self):
@@ -49,3 +53,45 @@ class RegistrationAPIViewTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("Ensure this field has at least 8 characters.",
                       response.data["errors"]["password"])
+
+    def test_api_cannot_create_user_without_alphanumeric_password(self):
+        response = self.client.post(
+            register_url,
+            { "user": user_with_a_non_numeric_password},
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            "password must contain a numeric character", 
+            response.data["errors"]["password"]
+            )
+
+    def test_api_cannot_create_user_with_invalid_email(self):
+        response = self.client.post(
+            register_url,
+            { "user": invalid_email},
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("Enter a valid email address.", 
+        response.data["errors"]["email"])
+
+
+    def test_api_cannot_create_user_with_short_username(self):
+        response = self.client.post(
+            register_url,
+            { "user": user_with_short_username},
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            message, 
+            response.data["errors"]["username"])
+
+
+    def test_api_cannot_create_user_with_special_character_in_username(self):
+        response = self.client.post(
+            register_url,
+            { "user": username_with_special_characters},
+            format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            message, 
+            response.data["errors"]["username"])

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ requests==2.21.0
 six==1.12.0
 urllib3==1.24.1
 whitenoise==4.1.2
+


### PR DESCRIPTION
#### What does this PR do?

Add relevant responses to signup fields during signup process

#### Description of Task to be completed?
- on signup, all the valid fields should be filled out otherwise user will be prompted to fill them out
- user is prompted to use the proper email format.
- user is asked to make password 8 characters long and also alphanumeric
- user cant signup with the same username or email twice
- on success a dictionary object of their username and email is returned.

#### How should this be manually tested?
- one is needed to clone this repository and pull this branch
- You can test for browser functionality using postman by running your server and testing out this route. http://127.0.0.1:8000/api/users/

#### valid input may look like:
``` {
  {
  "user":{
    "username": "jeckyll",
    "email": "hyde@dark.com",
    "password": "jakejake7"
  }
} 
````
#### response should there after look like:
``` 
{
    "user": {
        "email":  "hyde@dark.com",
        "username": "jeckyll"
    }
}
```


###### Otherwise
#### example, if you ran this
``` {
  "user":{
    "username": "jeckyll",
    "email": "hyde@dark.com",
    "password": "jakejake"
  }
} 
````
response should be :  
``` {
    "errors": {
        "password": [
            "password must contain a numeric character"
        ]
    }
}
```
#### What are the relevant pivotal tracker stories?
[https://www.pivotaltracker.com/story/show/164691215](url)




