### PR TITLE
#165177125 users should be able to read articles

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,11 +1,17 @@
 import json
 
 from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 class ArticleJSONRenderer(JSONRenderer):
     charset = 'utf-8'
 
     def render(self, data, media_type=None, renderer_context=None):
+        if isinstance(data, ReturnList):
+            return self.render_articles(data)
+
+        if isinstance(data, ReturnDict):
+            return self.render_article(data)
 
         article = data.get('article', None)
 
@@ -17,6 +23,20 @@ class ArticleJSONRenderer(JSONRenderer):
 
         return json.dumps({
             'article': article_dict
+        })
+
+    def render_articles(self, data):
+        articles = json.loads(
+            super(ArticleJSONRenderer, self).render(data).decode()
+        )
+        return json.dumps({
+            "articles": articles,
+            "articlesCount": len(articles)
+        })
+
+    def render_article(self, data):
+        return json.dumps({
+            "article": data
         })
 
     def convert_data_to_dictionary(self, data):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,8 +1,8 @@
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import serializers
 
 from authors.apps.authentication.models import User
 from authors.apps.authentication.serializers import UserSerializer
-from django.core.exceptions import ObjectDoesNotExist
 
 from .models import Article
 import readtime
@@ -32,4 +32,12 @@ class CreateArticleSerializer(serializers.ModelSerializer):
         result = read_time.text
         validated_data.update({'read_time': str(result+" read")})
         return Article.objects.create(**validated_data)
+
+
+
+class ReadArticlesSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Article
+        exclude = ('id',)
 

--- a/authors/apps/articles/tests/test_article_model.py
+++ b/authors/apps/articles/tests/test_article_model.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from authors.apps.articles.models import Article
-from authors.apps.articles.tests.test_data import valid_article
+from authors.apps.articles.tests.test_data import slug, valid_article
 from authors.apps.authentication.models import User
 from authors.apps.authentication.tests.test_data import valid_user
 
@@ -31,7 +31,7 @@ class ArticleTestCase(TestCase):
 
     def test_model_can_create_a_unique_slag(self):
         slug1 = self.article.get_unique_slag(self.title, 'slug')
-        expected = "how-to-train-your-dragon"
+        expected = slug
 
         new_article = Article(**valid_article)
         new_article.save()
@@ -40,3 +40,11 @@ class ArticleTestCase(TestCase):
         self.assertEqual(slug1, expected)
         self.assertNotEqual(slug1, slug2)
 
+    def test_model_can_get_all_articles(self):
+        self.article.save()
+        new_article = Article(**valid_article)
+        new_article.save()
+        EXPECTED = 2
+        articles = Article.objects.all()
+
+        self.assertEqual(articles.count(), EXPECTED)

--- a/authors/apps/articles/tests/test_data.py
+++ b/authors/apps/articles/tests/test_data.py
@@ -19,6 +19,7 @@ article_without_body = {
     "description": "Ever wonder how?"
 }
 
+
 valid_article_2= {
     "title": "How to train your dragon",
     "description": "Ever wonder how?",
@@ -46,3 +47,12 @@ valid_article_2= {
             talled  to check if the email the user signs up with is valid(like\
             their emails are not fake). The tests seem                                                                                                                                                                                                             Ask Question I added validate_mail and also installed py3dns to check if the email the user signs up with is valid(like their emails are not fake). The tests seem Ask Question I added validate_mail and also installed py3dns to check if the email the user signs up with is valid(like their emails are not fake). The tests seem  Ask Question I added validate_mail and also installed py3dns to check if the email the user signs up with is valid(like their emails are not fake). The tests seem Ask Question I added validate_mail and also installed py3dns to check if the email the user signs up with is valid(like their emails are not fake). The tests seem Ask Question I added validate_mail and also installed py3dns to check if the email the user signs up with is valid(like their emails are not fake). The tests seem v "
 }
+
+slug = "how-to-train-your-dragon"
+
+non_existent_slug = "Three-blind-mice"
+
+auth_error = "Authentication credentials were not provided."
+
+not_found = "Not found"
+

--- a/authors/apps/articles/tests/test_read_articles.py
+++ b/authors/apps/articles/tests/test_read_articles.py
@@ -1,0 +1,80 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from authors.apps.articles.models import Article
+from authors.apps.articles.tests.test_data import (auth_error,
+                                                   non_existent_slug,
+                                                   not_found, slug,
+                                                   valid_article)
+from authors.apps.authentication.models import User
+from authors.apps.authentication.tests.test_data import valid_user
+
+
+class ReadArticlesAPIViewTestCase(TestCase):
+
+    def setUp(self):
+        user = User.objects.create_user(**valid_user)
+
+        valid_article.update(
+            {"author_id": user.id}
+        )
+        # create three articles in the test database
+        COUNT = 3
+        while COUNT != 0:
+            article = Article(**valid_article)
+            article.save()
+            COUNT -= 1
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=user)
+
+    def test_api_can_read_articles_with_authenticated_user(self):
+        response = self.client.get(
+            '/api/articles/',
+        )
+        # we expect only the three articles created at setUp
+        # to be in our test database
+        EXPECTED = 3
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), EXPECTED)
+
+    def test_api_can_read_articles_with_an_unauthenticated_user(self):
+        self.client.logout()
+
+        response = self.client.get(
+            '/api/articles/',
+        )
+        # we expect only the three articles created at setUp
+        # to be in our test database
+        EXPECTED = 3
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), EXPECTED)
+
+    def test_api_can_read_an_article_with_authenticated_user(self):
+        response = self.client.get(
+            f'/api/articles/{slug}/'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(slug, response.data['slug'])
+
+    def test_api_can_read_an_article_with_an_unauthenticated_user(self):
+        self.client.logout()
+
+        response = self.client.get(
+            f'/api/articles/{slug}/'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn(slug, response.data['slug'])
+
+    def test_api_returns_error_when_retrieving_non_existent_slug(self):
+        response = self.client.get(
+            f'/api/articles/{non_existent_slug}/'
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn(not_found, response.data['detail'])

--- a/authors/apps/articles/tests/test_read_articles_serializer.py
+++ b/authors/apps/articles/tests/test_read_articles_serializer.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+from rest_framework.utils.serializer_helpers import ReturnList
+
+from authors.apps.articles.models import Article
+from authors.apps.articles.serializers import ReadArticlesSerializer
+from authors.apps.articles.tests.test_data import valid_article
+from authors.apps.authentication.models import User
+from authors.apps.authentication.tests.test_data import valid_user
+
+
+class ReadArticlesSerializerTestCase(TestCase):
+
+    def setUp(self):
+        user = User.objects.create_user(**valid_user)
+
+        valid_article.update(
+            {"author_id": user.id}
+        )
+        # create three articles in the test database
+        COUNT = 3
+        while COUNT != 0:
+            article = Article(**valid_article)
+            article.save()
+            COUNT -= 1
+
+        # initialize the serializer
+        self.serializer_class = ReadArticlesSerializer
+
+    def test_serializer_can_read_articles(self):
+        articles = Article.objects.all()
+        self.serializer = self.serializer_class(articles, many=True)
+
+        self.assertIsInstance(self.serializer.data, ReturnList)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,9 +1,10 @@
 from django.conf.urls import url
 from django.urls import path
-from .views import CreateArticleAPIView
 
+from .views import ArticlesAPIView, RetrieveArticleApiView
 
 urlpatterns = [
-    path('articles/', CreateArticleAPIView.as_view())
+    path('articles/', ArticlesAPIView.as_view()),
+    path('articles/<str:slug>/', RetrieveArticleApiView.as_view())
 ]
 

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,23 +1,25 @@
+from django.http import Http404
 from django.shortcuts import render
 from rest_framework import status
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.generics import RetrieveAPIView
+from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .models import Article
 from .renderers import ArticleJSONRenderer
-from .serializers import CreateArticleSerializer
+from .serializers import CreateArticleSerializer, ReadArticlesSerializer
 
 
-class CreateArticleAPIView(APIView):
-    permission_classes = (IsAuthenticated,)
+class ArticlesAPIView(APIView):
+    permission_classes = (IsAuthenticatedOrReadOnly,)
     renderer_classes = (ArticleJSONRenderer,)
-    serializer_class = CreateArticleSerializer
 
     def post(self, request):
         article = request.data.get('article', {})
         article.update({"author_id": request.user.id})
 
-        serializer = self.serializer_class(data=article)
+        serializer = CreateArticleSerializer(data=article)
         serializer.is_valid(raise_exception=True)
         saved_article = serializer.save()
         serializer.validated_data.update({"article": saved_article})
@@ -26,3 +28,28 @@ class CreateArticleAPIView(APIView):
             serializer.validated_data,
             status=status.HTTP_201_CREATED)
 
+    def get(self, request):
+        articles = Article.objects.filter().order_by('-created_at')
+        serializer = ReadArticlesSerializer(articles, many=True)
+        return Response(
+            serializer.data,
+            status=status.HTTP_200_OK)
+
+
+class RetrieveArticleApiView(RetrieveAPIView):
+    permission_classes = (AllowAny,)
+    renderer_classes = (ArticleJSONRenderer,)
+    serializer_class = ReadArticlesSerializer
+
+    def retrieve(self, request, slug):
+        article = self.get_object(slug)
+        serializer = self.serializer_class(article)
+        return Response(
+            serializer.data,
+            status=status.HTTP_200_OK)
+
+    def get_object(self, slug):
+        try:
+            return Article.objects.get(slug=slug)
+        except Article.DoesNotExist:
+            raise Http404


### PR DESCRIPTION
#### What does this PR do?

Adds the endpoints that enable reading of single and multiple articles

#### Description of Task to be completed?

- Added the endpoint that returns a list of all articles in the
database with the most recently added returned first.
- Added the endpoint to return a single article using a slug url

#### How should this be manually tested?

- After cloning this repository, create a virtual environment from the requirements file and change to this branch.
- After setting up the environment variables as specified in the `example.env` file, run the migrations then start the development server.
- In a rest client of your choice, register with the application and create articles. Refer to the README file for a description of the request body.
- You can now call the endpoint `/api/articles/` with a `GET` request to retrieve a list of all your articles with the most recently created returned first. Note that authentication is optional.
- Below is a sample request and response.
**Request**
`GET` `http://localhost:8000/api/articles/` 
**Response**
```
{ "articles":    [
         {
            "slug": "late-show-dinners-1",
            "title": "late show dinners",
            "description": "Lorem Ipsum",
            "body": "What is Lorem Ipsum?Lorem Ipsum is simply dummy text of the
                       printing and typesetting industry. Lorem Ipsum has been 
                       the industry's standard dummy",
            "created_at": "2019-04-12T07:11:26.277872Z",
            "updated_at": "2019-04-12T07:11:26.278301Z",
            "favorited": false,
            "favorites_count": 0,
            "read_time": "1 min read",
            "author": 16
        },
        {
            "slug": "late-show-dinners",
            "title": "late show dinners",
            "description": "Lorem Ipsum",
            "body": "What is Lorem Ipsum?Lorem Ipsum is simply dummy text of the
                       printing and typesetting industry. Lorem Ipsum has been 
                       the industry's standard dummy",
            "created_at": "2019-04-12T07:10:13.426804Z",
            "updated_at": "2019-04-12T07:10:13.426851Z",
            "favorited": false,
            "favorites_count": 0,
            "read_time": "1 min read",
            "author": 16
        }
    ],
    "articlesCount": 2
}
```

- You can also call the endpoint `/api/articles/<str:slug>` with a `GET` request to retrieve a single article based on its slug as below;
**Request**
`GET` `http://localhost:8000/api/articles/late-show-dinners/` 
**Response**
```
{
    "article": {
        "slug": "late-show-dinners",
        "title": "late show dinners",
        "description": "Lorem Ipsum",
        "body": "What is Lorem Ipsum?Lorem Ipsum is simply dummy text of the
                       printing and typesetting industry. Lorem Ipsum has been 
                       the industry's standard dummy",
        "created_at": "2019-04-12T07:10:13.426804Z",
        "updated_at": "2019-04-12T07:10:13.426851Z",
        "favorited": false,
        "favorites_count": 0,
        "read_time": "1 min read",
        "author": 16
    }
}
```
- If no records are found, the following responses are returned when getting articles
**Response for single article**
```
{
    "errors": {
        "detail": "Not found."
    }
}
```
  **Response for multiple articles**
```
{
    "articles" : [],
    "articlesCount": 0
}
```
#### Any background context you want to provide?

- The name of the view `CreateArticlesApiView` is changed to `ArticlesApiView`. This is because the
endpoint `/api/articles/` is expected to receive both `GET` and `POST` requests, ie it is used for reading as well as creating articles. Therefore this change was done to improve the **readability** of that feature.
- Since there is no profile model on the base branch, the response returned. contains an author's ID rather than their profile. This is to be implemented once the profile model becomes available on `develop`.

#### What are the relevant pivotal tracker stories?

[#165177125](https://www.pivotaltracker.com/story/show/165177125)
