### PR TITLE
Users should be able to edit their profiles

### DIFF
--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -34,6 +34,9 @@ class ProfileSerializer(serializers.ModelSerializer):
         some_one_being_followed = instance
         
         return follower.is_following(some_one_being_followed)
+        
+    def update(self, instance, validated_data):
+        return super().update(instance, validated_data)
 
 class RetrieveProfiles(serializers.ModelSerializer):
     username = serializers.CharField(source='user.username')

--- a/authors/apps/profiles/tests/test_data.py
+++ b/authors/apps/profiles/tests/test_data.py
@@ -9,3 +9,16 @@ valid_user2 ={
     "email" : "peter@email.com",
     "password" : "Pass1234"
 }
+
+profile_data = {
+    "profile": {
+        "bio": "I like cycling on weekends.",
+        "image": "https://images.io/my-images/me.png"
+    }
+}
+
+partial_profile_data = {
+    "profile": {
+        "image": "https://images.io/my-images/me.png"
+    }
+}

--- a/authors/apps/profiles/tests/test_update_profile.py
+++ b/authors/apps/profiles/tests/test_update_profile.py
@@ -1,0 +1,44 @@
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+from .test_data import (
+    valid_user, profile_data, partial_profile_data)
+from authors.apps.authentication.models import User
+
+
+class UpdateProfilesTestCase(TestCase):
+
+    def setUp(self):
+        user = User.objects.create_user(**valid_user)
+
+        self.client = APIClient()
+        self.client.force_authenticate(user=user)
+
+    def test_authenticated_user_can_update_their_profile(self):
+        response = self.client.put(
+            '/api/profiles/',
+            profile_data,
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, profile_data["profile"]["bio"])
+
+    def test_authenticated_user_can_partially_update_their_profile(self):
+        response = self.client.put(
+            '/api/profiles/',
+            partial_profile_data,
+            format="json"
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, partial_profile_data["profile"]["image"])
+
+    def test_authentication_required_to_update_a_profile(self):
+        self.client.logout()
+        response = self.client.put(
+            '/api/profiles/',
+            partial_profile_data,
+            format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,7 +1,7 @@
 from django.urls import path
 
 from .views import (
-    ProfileRetrieveAPIView, RetrieveProfilesView, 
+    ProfileRetrieveAPIView, RetrieveUpdateProfilesView, 
     FollowerFollowingAPIView, ProfileFollowAPIView
 )
 
@@ -9,7 +9,7 @@ from .views import (
 app_name = 'profiles'
 urlpatterns = [
     path('profiles/<str:username>/', ProfileRetrieveAPIView.as_view()),
-    path('profiles/', RetrieveProfilesView.as_view()),
+    path('profiles/', RetrieveUpdateProfilesView.as_view()),
     path('profiles/<str:username>/follow/', ProfileFollowAPIView.as_view()),
     path('profiles/<str:username>/following/', FollowerFollowingAPIView.as_view())
 ]


### PR DESCRIPTION
#### What does this PR do?

Adds the endpoint that enables a user to edit their profile.

#### Description of Task to be completed?

- Add endpoint to be called by a user when editing their profile.
- Ensure only authenticated users can edit their profiles.
- Check if a registered user has a profile, and create it if the user does not have one.

#### How should this be manually tested?

- After cloning this repository setting up the environment locally, switch to this branch and start the development server using the `python manage.py runserver` command.
- Open up your preferred REST client, such as Postman, and call the end point `/api/profiles/` as below.
**NOTE** This route is only accessible by authenticated users.
 **Request**
`PUT` `http://localhost:8000:/api/profiles/`
```
{
  "profile": {
         "bio": "I like bacon for breakfast",
         "image": "https://link-to-my-image.com/images/me.png"
   }
}
```
**Response**
```
{
    "profile": {
        "username": "test",
        "bio": "I like bacon for breakfast",
        "image": "https://link-to-my-image.com/images/me.png",
        "following": false
    }
}
```

#### Any background context you want to provide?

- If a  user does not yet have a profile, a profile will be created for that user.

#### What are the relevant pivotal tracker stories?

[#164691181](https://www.pivotaltracker.com/story/show/164691181)
